### PR TITLE
Update certificate_pinning_interceptor.dart

### DIFF
--- a/lib/certificate_pinning_interceptor.dart
+++ b/lib/certificate_pinning_interceptor.dart
@@ -12,7 +12,7 @@ class CertificatePinningInterceptor extends Interceptor{
   Future onRequest(RequestOptions options) async {
 
     final secure = await HttpCertificatePinning.check(
-        serverURL: options.baseUrl,
+        serverURL: options.uri.toString(),
         headerHttp: options.headers.map((a,b)=> MapEntry(a, b.toString())),
         sha: SHA.SHA256,
         allowedSHAFingerprints:_allowedSHAFingerprints,


### PR DESCRIPTION
https://github.com/diefferson/http_certificate_pinning/issues/4

This will check for the url that is being requested and not for the baseUrl.