### PR TITLE
Pinning a certain certificate in the chain

### DIFF
--- a/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
+++ b/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
@@ -72,10 +72,11 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
     val allowedFingerprints: List<String> = arguments.get("fingerprints") as List<String>
     val httpHeaderArgs: Map<String, String> = arguments.get("headers") as Map<String, String>
     val timeout: Int = arguments.get("timeout") as Int
-    val index: Int = arguments.get("index") as Int
+    // Nullable to support retro-compatibility, if not passed we pin the leaf (index 0)
+    val index: Int? = arguments.get("index") as Int?
     val type: String = arguments.get("type") as String
 
-    if (this.checkConnexion(serverURL, allowedFingerprints, httpHeaderArgs, timeout, index, type)) {
+    if (this.checkConnexion(serverURL, allowedFingerprints, httpHeaderArgs, timeout, index ?: 0, type)) {
       handler?.post {
         result.success("CONNECTION_SECURE")
       }
@@ -89,12 +90,12 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
 
 
   private fun checkConnexion(serverURL: String, allowedFingerprints: List<String>, httpHeaderArgs: Map<String, String>, timeout: Int, index: Int, type: String): Boolean {
-    val sha: String = this.getFingerprint(serverURL, timeout, index, httpHeaderArgs, type)
+    val sha: String = this.getFingerprint(serverURL, timeout, httpHeaderArgs, type, index)
     return allowedFingerprints.map { fp -> fp.toUpperCase().replace("\\s".toRegex(), "") }.contains(sha)
   }
 
   @Throws(IOException::class, NoSuchAlgorithmException::class, CertificateException::class, CertificateEncodingException::class, SocketTimeoutException::class)
-  private fun getFingerprint(httpsURL: String, connectTimeout: Int, certChainIndex: Int, httpHeaderArgs: Map<String, String>, type: String): String {
+  private fun getFingerprint(httpsURL: String, connectTimeout: Int, httpHeaderArgs: Map<String, String>, type: String, certChainIndex: Int): String {
 
     val url = URL(httpsURL)
     val httpClient: HttpsURLConnection = url.openConnection() as HttpsURLConnection

--- a/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
+++ b/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
@@ -72,9 +72,10 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
     val allowedFingerprints: List<String> = arguments.get("fingerprints") as List<String>
     val httpHeaderArgs: Map<String, String> = arguments.get("headers") as Map<String, String>
     val timeout: Int = arguments.get("timeout") as Int
+    val index: Int = arguments.get("index") as Int
     val type: String = arguments.get("type") as String
 
-    if (this.checkConnexion(serverURL, allowedFingerprints, httpHeaderArgs, timeout, type)) {
+    if (this.checkConnexion(serverURL, allowedFingerprints, httpHeaderArgs, timeout, index, type)) {
       handler?.post {
         result.success("CONNECTION_SECURE")
       }
@@ -87,13 +88,13 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
   }
 
 
-  private fun checkConnexion(serverURL: String, allowedFingerprints: List<String>, httpHeaderArgs: Map<String, String>, timeout: Int, type: String): Boolean {
-    val sha: String = this.getFingerprint(serverURL, timeout, httpHeaderArgs, type)
+  private fun checkConnexion(serverURL: String, allowedFingerprints: List<String>, httpHeaderArgs: Map<String, String>, timeout: Int, index: Int, type: String): Boolean {
+    val sha: String = this.getFingerprint(serverURL, timeout, index, httpHeaderArgs, type)
     return allowedFingerprints.map { fp -> fp.toUpperCase().replace("\\s".toRegex(), "") }.contains(sha)
   }
 
   @Throws(IOException::class, NoSuchAlgorithmException::class, CertificateException::class, CertificateEncodingException::class, SocketTimeoutException::class)
-  private fun getFingerprint(httpsURL: String, connectTimeout: Int, httpHeaderArgs: Map<String, String>, type: String): String {
+  private fun getFingerprint(httpsURL: String, connectTimeout: Int, certChainIndex: Int, httpHeaderArgs: Map<String, String>, type: String): String {
 
     val url = URL(httpsURL)
     val httpClient: HttpsURLConnection = url.openConnection() as HttpsURLConnection
@@ -109,7 +110,14 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
       return ""
     }
 
-    val cert: Certificate = httpClient.serverCertificates[0] as Certificate
+    // Means certChainIndex is out of range
+    if (httpClient.serverCertificates.size < certChainIndex)
+    {
+      println("INDEX PASSED IS OUT OF RANGE. CERTIFICATE CHAIN LENGTH IS: ${httpClient.serverCertificates.size}")
+      return "";
+    }
+
+    val cert: Certificate = httpClient.serverCertificates[certChainIndex] as Certificate
     return this.hashString(type, cert.encoded)
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,7 @@ class _PiningSslData {
   Map<String, String> headerHttp = {};
   String allowedSHAFingerprint = '';
   int timeout = 0;
+  int? index;
   SHA? sha;
 }
 
@@ -29,13 +30,8 @@ class _MyAppState extends State<MyApp> {
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
-  check(
-    String url,
-    String fingerprint,
-    SHA sha,
-    Map<String, String> headerHttp,
-    int timeout,
-  ) async {
+  check(String url, String fingerprint, SHA sha, Map<String, String> headerHttp,
+      int timeout, int? index) async {
     List<String> allowedShA1FingerprintList = [];
     allowedShA1FingerprintList.add(fingerprint);
 
@@ -46,7 +42,8 @@ class _MyAppState extends State<MyApp> {
           headerHttp: headerHttp,
           sha: sha,
           allowedSHAFingerprints: allowedShA1FingerprintList,
-          timeout: timeout);
+          timeout: timeout,
+          index: index);
 
       // If the widget was removed from the tree while the asynchronous platform
       // message was in flight, we want to discard the reply rather than calling
@@ -77,12 +74,12 @@ class _MyAppState extends State<MyApp> {
       _formKey.currentState?.save(); // Save our form now.
 
       check(
-        _data.serverURL,
-        _data.allowedSHAFingerprint,
-        _data.sha ?? SHA.SHA256,
-        _data.headerHttp,
-        _data.timeout,
-      );
+          _data.serverURL,
+          _data.allowedSHAFingerprint,
+          _data.sha ?? SHA.SHA256,
+          _data.headerHttp,
+          _data.timeout,
+          _data.index);
     }
   }
 
@@ -173,6 +170,17 @@ class _MyAppState extends State<MyApp> {
                       },
                       onSaved: (value) {
                         _data.timeout = int.tryParse(value ?? '') ?? 0;
+                      },
+                    ),
+                    TextFormField(
+                      keyboardType: TextInputType.number,
+                      initialValue: '1',
+                      decoration: const InputDecoration(
+                        hintText: '1 for the root',
+                        labelText: 'Index',
+                      ),
+                      onSaved: (value) {
+                        _data.index = int.tryParse(value ?? '');
                       },
                     ),
                     Container(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -174,9 +174,9 @@ class _MyAppState extends State<MyApp> {
                     ),
                     TextFormField(
                       keyboardType: TextInputType.number,
-                      initialValue: '1',
+                      initialValue: '0',
                       decoration: const InputDecoration(
-                        hintText: '1 for the root',
+                        hintText: '0 for the leaf, usually 2 or 3 for the root',
                         labelText: 'Index',
                       ),
                       onSaved: (value) {

--- a/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
+++ b/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
@@ -6,6 +6,7 @@ import Alamofire
 public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
 
     let manager = Alamofire.SessionManager.default
+    var index: Int? = nil
     var fingerprints: Array<String>?
     var flutterResult: FlutterResult?
 
@@ -61,6 +62,10 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
             timeout = timeoutArg
         }
         
+        if let indexArg = args["index"] as? Int {
+            self.index = indexArg
+        }
+        
         let manager = Alamofire.SessionManager(
             configuration: URLSessionConfiguration.default
         )
@@ -90,9 +95,10 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
             // To retain
             let _ = manager
         }
-
+        
         manager.delegate.sessionDidReceiveChallenge = { session, challenge in
-            guard let serverTrust = challenge.protectionSpace.serverTrust, let certificate = SecTrustGetCertificateAtIndex(serverTrust, 0) else {
+            guard let serverTrust = challenge.protectionSpace.serverTrust else {
+                // Handle the case where serverTrust is nil
                 flutterResult(
                     FlutterError(
                         code: "ERROR CERT",
@@ -100,9 +106,40 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
                         details: nil
                     )
                 )
-                
                 return (.cancelAuthenticationChallenge, nil)
             }
+            
+            // As default we check the leaf fingerprint
+            // If the user specifies an index (1 for the root) we perform the check there
+            let certificateCount = SecTrustGetCertificateCount(serverTrust)
+            let unwrappedIndex = (self.index == nil || self.index == 0) ? certificateCount - 1 : self.index!
+            let certificateIndex = certificateCount - unwrappedIndex
+            
+            guard certificateIndex >= 0 else {
+                // Handle the case where there are no certificates in the chain
+                flutterResult(
+                    FlutterError(
+                        code: "ERROR CERT",
+                        message: "Invalid Certificate",
+                        details: nil
+                    )
+                )
+                return (.cancelAuthenticationChallenge, nil)
+            }
+            
+            guard let certificate = SecTrustGetCertificateAtIndex(serverTrust, certificateIndex) else {
+                // Handle the case where the root certificate cannot be retrieved
+                flutterResult(
+                    FlutterError(
+                        code: "ERROR CERT",
+                        message: "Invalid Certificate",
+                        details: nil
+                    )
+                )
+                return (.cancelAuthenticationChallenge, nil)
+            }
+
+            
 
             // Set SSL policies for domain name check
             let policies: [SecPolicy] = [SecPolicyCreateSSL(true, (challenge.protectionSpace.host as CFString))]

--- a/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
+++ b/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
@@ -109,7 +109,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
                 return (.cancelAuthenticationChallenge, nil)
             }
             
-            // As default we check the leaf fingerprint
+            // As default we check the leaf fingerprint (certificateCount - 1)
             // If the user specifies an index (1 for the root) we perform the check there
             let certificateCount = SecTrustGetCertificateCount(serverTrust)
             let unwrappedIndex = (self.index == nil || self.index == 0) ? certificateCount - 1 : self.index!
@@ -120,7 +120,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
                 flutterResult(
                     FlutterError(
                         code: "ERROR CERT",
-                        message: "Invalid Certificate",
+                        message: "Invalid Certificate - No certificates in the chain",
                         details: nil
                     )
                 )
@@ -128,18 +128,16 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
             }
             
             guard let certificate = SecTrustGetCertificateAtIndex(serverTrust, certificateIndex) else {
-                // Handle the case where the root certificate cannot be retrieved
+                // Handle the case where the certificate cannot be retrieved
                 flutterResult(
                     FlutterError(
                         code: "ERROR CERT",
-                        message: "Invalid Certificate",
+                        message: "Invalid Certificate - Cannot be retrieved in the chain",
                         details: nil
                     )
                 )
                 return (.cancelAuthenticationChallenge, nil)
-            }
-
-            
+            }    
 
             // Set SSL policies for domain name check
             let policies: [SecPolicy] = [SecPolicyCreateSSL(true, (challenge.protectionSpace.host as CFString))]

--- a/lib/src/http_certificate_pinning.dart
+++ b/lib/src/http_certificate_pinning.dart
@@ -17,20 +17,21 @@ class HttpCertificatePinning {
     _channel.setMethodCallHandler(_platformCallHandler);
   }
 
-  static Future<String> check({
-    required String serverURL,
-    required SHA sha,
-    required List<String> allowedSHAFingerprints,
-    Map<String, String>? headerHttp,
-    int? timeout,
-  }) async {
+  static Future<String> check(
+      {required String serverURL,
+      required SHA sha,
+      required List<String> allowedSHAFingerprints,
+      Map<String, String>? headerHttp,
+      int? timeout,
+      int? index}) async {
     final Map<String, dynamic> params = <String, dynamic>{
       "url": serverURL,
       "headers": headerHttp ?? {},
       "type": sha.toString().split(".").last,
       "fingerprints":
           allowedSHAFingerprints.map((a) => a.replaceAll(":", "")).toList(),
-      "timeout": timeout
+      "timeout": timeout,
+      "index": index
     };
     String resp = await _channel.invokeMethod('check', params);
     return resp;


### PR DESCRIPTION
Hello,
I am submitting a pull request to pin a specific certificate in the certificate chain.
I decided to expand the original library in order to support the root/intermediate certificate pinning, which might be a use-case needed by some people/users (for example myself).
Instead of just forking it for me and my team I think it would also be helpful if we can add it to the original library for the entire Flutter community.
The main change is a new parameter in the `check` method called `index`.
I defined it as a nullable Int in order to support the retro compatibility.
The native implementation take it as 0 in case is not passed (as was doing before) in order to pin the leaf (same behaviour as before).

I'm not the best kotlin/swift dev out there so I am open to any suggestion to improve the codebase before having my PR approved.