### PR TITLE
add dio constraints, update alamofire, add vscode helper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "[dart]": {
+      "editor.formatOnSave": true
+    },
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    },
+  }
+  

--- a/example/.vscode/launch.json
+++ b/example/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "request": "launch",
+            "type": "dart",
+            "program": "lib/main.dart",
+            "flutterMode": "debug",
+        },
+    ]
+}

--- a/example/.vscode/settings.json
+++ b/example/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "[dart]": {
+      "editor.formatOnSave": true
+    },
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    },
+  }
+  

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - CryptoSwift (1.7.1)
   - Flutter (1.0.0)
   - http_certificate_pinning (1.0.3):
-    - Alamofire (~> 4.7)
+    - Alamofire (~> 4.9.1)
     - CryptoSwift
     - Flutter
 
@@ -26,8 +26,8 @@ SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   CryptoSwift: d3d18dc357932f7e6d580689e065cf1f176007c1
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  http_certificate_pinning: 23157eae20c5887e49372b3cbe7a1d5863eb9bad
+  http_certificate_pinning: 2a9097b304c7ea3b51804af46d381aba8108fa29
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/ios/http_certificate_pinning.podspec
+++ b/ios/http_certificate_pinning.podspec
@@ -16,7 +16,7 @@ Https Certificate pinning for Flutter
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'CryptoSwift'
-  s.dependency 'Alamofire', '~> 4.7'
+  s.dependency 'Alamofire', '~> 4.9.1'
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/lib/src/dio/certificate_pinning_interceptor.dart
+++ b/lib/src/dio/certificate_pinning_interceptor.dart
@@ -8,15 +8,16 @@ import 'package:http_certificate_pinning/http_certificate_pinning.dart';
 class CertificatePinningInterceptor extends Interceptor {
   final List<String> _allowedSHAFingerprints;
   final int _timeout;
+  final bool _callFollowingErrorInterceptor;
   Future<String>? secure = Future.value('');
 
   CertificatePinningInterceptor({
     List<String>? allowedSHAFingerprints,
     int timeout = 0,
-  })  : _allowedSHAFingerprints = allowedSHAFingerprints != null
-            ? allowedSHAFingerprints
-            : <String>[],
-        _timeout = timeout;
+    bool callFollowingErrorInterceptor = false,
+  })  : _allowedSHAFingerprints = allowedSHAFingerprints ?? [],
+        _timeout = timeout,
+        _callFollowingErrorInterceptor = callFollowingErrorInterceptor;
 
   @override
   Future onRequest(
@@ -31,7 +32,7 @@ class CertificatePinningInterceptor extends Interceptor {
 
       var baseUrl = options.baseUrl;
 
-      if(options.path.contains('http') || options.baseUrl.isEmpty) {
+      if (options.path.contains('http') || options.baseUrl.isEmpty) {
         baseUrl = options.path;
       }
 
@@ -54,6 +55,7 @@ class CertificatePinningInterceptor extends Interceptor {
             requestOptions: options,
             error: CertificateNotVerifiedException(),
           ),
+          _callFollowingErrorInterceptor,
         );
       }
     } on Exception catch (e) {
@@ -70,6 +72,7 @@ class CertificatePinningInterceptor extends Interceptor {
           requestOptions: options,
           error: error,
         ),
+        _callFollowingErrorInterceptor,
       );
     }
   }


### PR DESCRIPTION
1. from #36 Add the callFollowingErrorInterceptor flag to the Dio interceptor. This allows users of this package to implement a single interceptor for error handling and deal with the error universally. This flag is false by default for backward compatibility 
2. update Alamofire to 4.9.1 
3. add helper for vscode