### PR TITLE
Fix: set sdk constraints to ">=3.2.0 <4.0.0"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.3
 homepage: https://github.com/diefferson/http_certificate_pinning
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
   flutter: ">=1.12.0"
 
 dependencies:


### PR DESCRIPTION
Hi!
http: ^1.1.2 requires SDK version of at least 3.2. Let's bump it in pubspec.yaml
<img width="975" alt="image" src="https://github.com/diefferson/http_certificate_pinning/assets/87417977/ce9e5e25-8ef9-403a-b35d-8fef37297e28">
