### PR TITLE
Fix: fixed an unnecessary certificate validation check

### DIFF
--- a/lib/src/dio/certificate_pinning_interceptor.dart
+++ b/lib/src/dio/certificate_pinning_interceptor.dart
@@ -20,7 +20,6 @@ class CertificatePinningInterceptor extends Interceptor {
             : <String>[],
         _timeout = timeout;
 
-
   @override
   Future onRequest(
     RequestOptions options,
@@ -46,10 +45,9 @@ class CertificatePinningInterceptor extends Interceptor {
         timeout: _timeout,
       );
 
-      secure?.whenComplete(() => secure = null);
-      final secureString = await secure ?? '';
+      final secureString = await secure?.whenComplete(() => secure = null);
 
-      if (secureString.contains('CONNECTION_SECURE')) {
+      if (secureString?.contains('CONNECTION_SECURE') ?? false) {
         return super.onRequest(options, handler);
       } else {
         handler.reject(


### PR DESCRIPTION
This causes unnecessary certificate checking. And besides it leads to throwing unhandled exceptions that will not be handled by try/catch block:
```dart
      secure?.whenComplete(() => secure = null);
      final secureString = await secure ?? '';
```
