### PR TITLE
fix: "NO_INTERNET" exception not shown bug in dio interceptor was fixed.

### DIFF
--- a/lib/src/dio/certificate_pinning_interceptor.dart
+++ b/lib/src/dio/certificate_pinning_interceptor.dart
@@ -63,6 +63,13 @@ class CertificatePinningInterceptor extends Interceptor {
 
       if (e is PlatformException && e.code == 'CONNECTION_NOT_SECURE') {
         error = const CertificateNotVerifiedException();
+      } else if (e is PlatformException && e.code == 'NO_INTERNET') {
+        return handler.reject(
+          DioException.connectionError(
+            requestOptions: options,
+            reason: 'NO_INTERNET',
+          ),
+        );
       } else {
         error = CertificateCouldNotBeVerifiedException(e);
       }


### PR DESCRIPTION
While there wasn't any internet connection, the interceptor was returning a **CertificateCouldNotBeVerifiedException**. Then Dio assumed that exception was an Unknown Exception. I fixed this bug by returning **DioException.connectionError** instead of **CertificateCouldNotBeVerifiedException**.