### PR TITLE
Fix for concurrent requests on iOS

### DIFF
--- a/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
+++ b/ios/Classes/SwiftHttpCertificatePinningPlugin.swift
@@ -6,8 +6,6 @@ import Alamofire
 public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
 
     let manager = Alamofire.SessionManager.default
-    var fingerprints: Array<String>?
-    var flutterResult: FlutterResult?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "http_certificate_pinning", binaryMessenger: registrar.messenger())
@@ -41,7 +39,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
     ){
         guard let urlString = args["url"] as? String,
               let headers = args["headers"] as? Dictionary<String, String>,
-              let fingerprints = args["fingerprints"] as? Array<String>,
+              let fingerprints = args["fingerprints"] as? Array<String>?,
               let type = args["type"] as? String
         else {
             flutterResult(
@@ -53,9 +51,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
             )
             return
         }
-
-        self.fingerprints = fingerprints
-
+        
         var timeout = 60
         if let timeoutArg = args["timeout"] as? Int {
             timeout = timeoutArg
@@ -121,7 +117,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
             }
 
             var isSecure = false
-            if var fp = self.fingerprints {
+            if var fp = fingerprints {
                 fp = fp.compactMap { (val) -> String? in
                     val.replacingOccurrences(of: " ", with: "")
             }
@@ -138,7 +134,7 @@ public class SwiftHttpCertificatePinningPlugin: NSObject, FlutterPlugin {
                 flutterResult(
                     FlutterError(
                         code: "CONNECTION_NOT_SECURE",
-                        message: nil,
+                        message: "serverCertSha: \(serverCertSha) - fingerprints: \(fingerprints)",
                         details: nil
                     )
                 )


### PR DESCRIPTION
When executing requests at the same time with different hostnames/fingerprints, the current version of the plugin will mix up the fingerprints as they are saved on class level. That results sometimes in unexpected certificate errors.

With this bugfix I changed the behaviour so that always the original fingerprint is used. 