### PR TITLE
Fix for HttpCertificatePinningPlugin.kt - uppercase should be used instead of toUpperCase

### DIFF
--- a/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
+++ b/android/src/main/kotlin/diefferson/http_certificate_pinning/HttpCertificatePinningPlugin.kt
@@ -96,7 +96,7 @@ public class HttpCertificatePinningPlugin : FlutterPlugin, MethodCallHandler {
 
   private fun checkConnexion(serverURL: String, allowedFingerprints: List<String>, httpHeaderArgs: Map<String, String>, timeout: Int, type: String): Boolean {
     val sha: String = this.getFingerprint(serverURL, timeout, httpHeaderArgs, type)
-    return allowedFingerprints.map { fp -> fp.toUpperCase().replace("\\s".toRegex(), "") }.contains(sha)
+    return allowedFingerprints.map { fp -> fp.uppercase().replace("\\s".toRegex(), "") }.contains(sha)
   }
 
   @Throws(IOException::class, NoSuchAlgorithmException::class, CertificateException::class, CertificateEncodingException::class, SocketTimeoutException::class)


### PR DESCRIPTION
String.toUpperCase() is deprecated and uppercase() must be used  instead