### PR TITLE
Fix for failed certificate check on iOS

### DIFF
--- a/ios/Classes/CertificateSHAFingerprintTrustEvalator.swift
+++ b/ios/Classes/CertificateSHAFingerprintTrustEvalator.swift
@@ -1,52 +1,79 @@
 import Foundation
+import CryptoKit
+import CommonCrypto
 import Alamofire
 
-class CertificateSHAFingerprintTrustEvaluator: ServerTrustEvaluating {
+
+final class CertificateSHAFingerprintTrustEvaluator: ServerTrustEvaluating {
     let pinnedFingerprints: [String]
     let type: String
-
+    
     init(pinnedFingerprints: [String],  type: String) {
         self.type = type
         self.pinnedFingerprints = pinnedFingerprints.map { $0.lowercased() }
     }
-
+    
     func evaluate(_ trust: SecTrust, forHost host: String) throws {
-
         let policies: [SecPolicy] = [SecPolicyCreateSSL(true, host as CFString)]
         SecTrustSetPolicies(trust, policies as CFTypeRef)
-
+        
         var result: SecTrustResultType = .invalid
         SecTrustEvaluate(trust, &result)
-
+        
         let isServerTrusted = (result == .unspecified || result == .proceed)
         guard isServerTrusted, let certificate = SecTrustGetCertificateAtIndex(trust, 0) else {
             throw AFError.serverTrustEvaluationFailed(
                 reason: .trustEvaluationFailed(error: nil)
             )
         }
-
+        
         let serverCertData = SecCertificateCopyData(certificate) as Data
         var serverCertSha = serverCertData.sha256().toHexString()
-
+        
         if(type == "SHA1"){
             serverCertSha = serverCertData.sha1().toHexString()
         }
-
+        
         var isSecure = false
         let fps = self.pinnedFingerprints.compactMap { (val) -> String? in
             val.replacingOccurrences(of: " ", with: "")
         }
-
+        
         isSecure = fps.contains(where: { (value) -> Bool in
             value.caseInsensitiveCompare(serverCertSha) == .orderedSame
         })
-
-
+        
         if !isSecure {
             throw AFError.serverTrustEvaluationFailed(
                 reason: .noCertificatesFound
             )
         }
+        
+    }
+}
 
+extension Data {
+    func sha256() -> Data {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        
+        _ = self.withUnsafeBytes { buffer in
+            CC_SHA256(buffer.baseAddress, CC_LONG(self.count), &digest)
+        }
+        
+        return Data(bytes: digest, count: digest.count)
+    }
+    
+    func sha1() -> Data {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        
+        _ = self.withUnsafeBytes { buffer in
+            CC_SHA1(buffer.baseAddress, CC_LONG(self.count), &digest)
+        }
+        
+        return Data(bytes: digest, count: digest.count)
+    }
+    
+    func toHexString() -> String {
+        return self.map { String(format: "%02hhx", $0) }.joined()
     }
 }

--- a/ios/Classes/HttpCertificatePinningPlugin.swift
+++ b/ios/Classes/HttpCertificatePinningPlugin.swift
@@ -4,7 +4,6 @@ import CryptoSwift
 import Alamofire
 
 public class HttpCertificatePinningPlugin: NSObject, FlutterPlugin {
-
     var fingerprints: Array<String>?
     var flutterResult: FlutterResult?
 
@@ -16,18 +15,18 @@ public class HttpCertificatePinningPlugin: NSObject, FlutterPlugin {
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch (call.method) {
-            case "check":
-                if let _args = call.arguments as? Dictionary<String, AnyObject> {
-                    self.check(call: call, args: _args, flutterResult: result)
-                } else {
-                    result(
-                        FlutterError(
-                            code: "Invalid Arguments",
-                            message: "Please specify arguments",
-                            details: nil)
-                    )
-                }
-                break
+        case "check":
+            if let _args = call.arguments as? Dictionary<String, AnyObject> {
+                self.check(call: call, args: _args, flutterResult: result)
+            } else {
+                result(
+                    FlutterError(
+                        code: "Invalid Arguments",
+                        message: "Please specify arguments",
+                        details: nil)
+                )
+            }
+            break
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -70,9 +69,9 @@ public class HttpCertificatePinningPlugin: NSObject, FlutterPlugin {
 
         manager.request(urlString, method: .get, parameters: headers).validate().responseData() { response in
             switch response.result {
-                case .success:
-                    flutterResult("CONNECTION_SECURE")
-                    break
+            case .success:
+                flutterResult("CONNECTION_SECURE")
+                break
             case .failure(let error):
                 if let responseCode = error.responseCode, (200...599).contains(responseCode) {
                     flutterResult("CONNECTION_SECURE")

--- a/ios/Classes/HttpCertificatePinningPlugin.swift
+++ b/ios/Classes/HttpCertificatePinningPlugin.swift
@@ -74,14 +74,17 @@ public class HttpCertificatePinningPlugin: NSObject, FlutterPlugin {
                     flutterResult("CONNECTION_SECURE")
                     break
             case .failure(let error):
-                flutterResult(
-                    FlutterError(
-                        code: "CONNECTION_NOT_SECURE",
-                        message: error.localizedDescription,
-                        details: nil
+                if let responseCode = error.responseCode, (200...599).contains(responseCode) {
+                    flutterResult("CONNECTION_SECURE")
+                } else {
+                    flutterResult(
+                        FlutterError(
+                            code: "CONNECTION_NOT_SECURE",
+                            message: error.localizedDescription,
+                            details: nil
+                        )
                     )
-                )
-
+                }
                 break
             }
 


### PR DESCRIPTION
Fix for #75.
Additionally considering any HTTP status code as valid. The status code will be nil if the certificate check fails.
I suggest that someone with more knowledge in Swift and Alamofire will review this PR before merging.